### PR TITLE
Forgot to re-render the quarto, leaving a dangling about.qmd link

### DIFF
--- a/_site/index.html
+++ b/_site/index.html
@@ -96,11 +96,6 @@ ul.task-list li input[type="checkbox"] {
     <a class="nav-link active" href="./index.html" aria-current="page"> 
 <span class="menu-text">Home</span></a>
   </li>  
-  <li class="nav-item">
-    <span class="nav-link">
-<span class="menu-text">about.qmd</span>
-    </span>
-  </li>  
 </ul>
           </div> <!-- /navcollapse -->
             <div class="quarto-navbar-tools">


### PR DESCRIPTION
in the nav header